### PR TITLE
Fix tmux/neovim/iterm2 coloring

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -3,8 +3,15 @@
 if-shell -b '[ "$(echo "$(tmux -V | cut -c 6-) < 2.6" | bc)" = 1 ] && [ -n "$(command -v reattach-to-user-namespace)" ]' \
     "set-option -g default-command 'reattach-to-user-namespace -l $SHELL'"
 
-# tmux display things in 256 colors
-set -g default-terminal "screen-256color"
+# Tmux coloring
+# set the default-terminal to "screen-256color" or "tmux-256color"
+# "tmux-256color" supports italic font rendering, "screen-256color" does not.
+# OSX does not currently ship with tmux-256color, so it must be downloaded and installed.
+set-option -g default-terminal "screen-256color"
+# Enable RGB (true-color) support in tmux.
+# The following lets tmux know that the outside terminal supports true colors
+# If the outside terminal does not support RGB/Tc, then comment this out
+set-option -ga terminal-overrides ",xterm-256color*:Tc:RGB"
 
 set -g history-limit 20000
 

--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -95,6 +95,8 @@ if has('vim_starting')
 endif
 
 " Coloring
+set background=dark
+colorscheme Tomorrow-Night-Eighties
 if exists('+termguicolors')
   let &t_8f = "\<Esc>[38;2;%lu;%lu;%lum"
   let &t_8b = "\<Esc>[48;2;%lu;%lu;%lum"
@@ -106,8 +108,6 @@ set colorcolumn=120         " Draw a vertical line at 120 characters
 syntax sync minlines=256    " start highlighting from 256 lines backwards
 " set re=1                    " use explicit old regexpengine, which seems to be faster
 set re=0                " Use the newer regex engine so syntax highlighting doesn't get messed up
-set background=dark
-colorscheme Tomorrow-Night-Eighties
 set t_Co=256            " Explicitly tell vim that the terminal supports 256 colors
 set number              " show line numbers
 set relativenumber      " show relative line numbers


### PR DESCRIPTION
This post describes how to setup iterm2/tmux/vim for true-color support
https://jdhao.github.io/2018/10/19/tmux_nvim_true_color/

This gist has instructions for tmux coloring and background the default-terminal settings with italics
https://gist.github.com/bbqtd/a4ac060d6f6b9ea6fe3aabe735aa9d95