### PR TITLE
Create root code dir and let git create repo dir

### DIFF
--- a/shell/functions.sh
+++ b/shell/functions.sh
@@ -183,7 +183,7 @@ function gheclone() {
         return
     fi
 
-    _internalClone "${GHE_ORG}" $1
+    _internalClone "${GHE_ORG}" "$1"
 }
 
 function ghclone() {
@@ -192,13 +192,14 @@ function ghclone() {
         return
     fi
 
-    _internalClone "github.com" $1
+    _internalClone "github.com" "$1"
 }
 
 function _internalClone() {
     local account=$1
     local repo=$2
-    local dest="${ROOT_CODE_DIR:-$GOPATH/src}/$account/$repo"
+    local codeDir="${ROOT_CODE_DIR:-$GOPATH/src}/$account"
+    local dest="$codeDir/$repo"
 
     # Ensure the repo is not already cloned
     if [ -e "$dest" ]; then
@@ -206,9 +207,13 @@ function _internalClone() {
         return
     fi
 
-    mkdir -p "$dest"
+    # Ensure the root code dir exists before cloning
+    if [ ! -d "$codeDir" ]; then
+        local colorYellow='\033[1;33m'
+        local colorNone='\033[0m'
+        echo -e "${colorYellow}Creating $codeDir since it does not exist${colorNone}"
+        mkdir -p "$codeDir"
+    fi
 
-    git clone git@$account:$repo $dest
-
-    cd $dest
+    git clone git@"$account":"$repo" "$dest" && cd "$dest"
 }


### PR DESCRIPTION
Previously we would create the repo dir before attempting to clone. If a repo was invalid or didn't exist, then we would create the repo and `cd` to it, but no repo would be cloned.
Rather than create the repo before cloning, we defer to `git clone` to create the repo dir.

Additionally, we create the root code directory if it doesn't exist to make it easier to bootstrap a system from scratch, otherwise the directory structure would need to be created before running `ghclone` || `gheclone` on a fresh system.